### PR TITLE
Stretch wallet cards to full width

### DIFF
--- a/src/components/WalletProviderModal/WalletProviderModal.tsx
+++ b/src/components/WalletProviderModal/WalletProviderModal.tsx
@@ -64,7 +64,8 @@ const StyledWalletsWrapper = styled.div`
 `
 
 const StyledWalletCard = styled.div`
-  flex-basis: calc(50% - ${(props) => props.theme.spacing[2]}px);
+  flex-basis: calc(100% - ${(props) => props.theme.spacing[2]}px);
+  margin-bottom: ${(props) => props.theme.spacing[1]}px;
 `
 
 export default WalletProviderModal


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/80589610/120123474-bf719500-c1b7-11eb-8f3e-57ec08855cb9.png)
This empty space has been bugging me from the start. Fixed the style for it to be "correct size" + added small margin between the cards.

![image](https://user-images.githubusercontent.com/80589610/120123519-edef7000-c1b7-11eb-868e-5c964beb901e.png)
