### PR TITLE
Remove unnecessary media query from logo wrapper

### DIFF
--- a/src/components/TopBar/TopBar.tsx
+++ b/src/components/TopBar/TopBar.tsx
@@ -104,9 +104,6 @@ const TopBar: React.FC<TopBarProps> = ({ onPresentMobileMenu }) => {
 
 const StyledLogoWrapper = styled.div`
   width: 100px;
-  @media (max-width: 400px) {
-    width: auto;
-  }
 `
 
 // const StyledTopBar = styled.div``


### PR DESCRIPTION
Prolly you were already figuring this out, but here's PR for the mobile logo getting in the way.

Figured the media query was unnecessary so deleted it altogether. 