### PR TITLE
UI improvements

### DIFF
--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -1,3 +1,4 @@
+import BigNumber from 'bignumber.js'
 import React, { useState, useEffect } from 'react'
 import styled from 'styled-components'
 import * as FaIcons from 'react-icons/fa'
@@ -9,10 +10,21 @@ import AccountButton from './components/AccountButton'
 import './components/Navbar.css'
 import { IconContext } from 'react-icons'
 import useWindowWidth from '../../hooks/useWindowWidth'
+import {
+  getFUSDPrice,
+  getSteakPrice,
+} from '../../sushi/utils'
+import useSushi from '../../hooks/useSushi'
+import fusdImg from '../../assets/img/fusd_icons/fusd.png'
+import steakImg from '../../assets/img/steak_icons/steak_orange.png'
 
 const NavBar: React.FC = () => {
   const windowWidth = useWindowWidth()
+  const sushi = useSushi()
+
   const [sidebar, setSidebar] = useState(false)
+  const [fusdPrice, setFusdPrice] = useState<BigNumber>()
+  const [steakPrice, setSteakPrice] = useState<BigNumber>()
 
   const toggleSidebar = () => setSidebar(!sidebar)
 
@@ -22,6 +34,15 @@ const NavBar: React.FC = () => {
     if (!shouldSidebarBeOpen()) {
       setSidebar(false)
     }
+    setTokenPrices()
+  }
+
+  const setTokenPrices = async () => {
+    if (sushi) {
+      const prices = await Promise.all([getFUSDPrice(sushi), getSteakPrice(sushi)])
+      setFusdPrice(new BigNumber(prices[0]))
+      setSteakPrice(new BigNumber(prices[1]))
+    }
   }
 
   useEffect(() => {
@@ -29,6 +50,11 @@ const NavBar: React.FC = () => {
       setSidebar(true)
     }
   }, [])
+
+  useEffect(() => {
+    if (!fusdPrice || !steakPrice)
+      setTokenPrices()
+  }, [sushi])
 
   return (
     <>
@@ -62,6 +88,10 @@ const NavBar: React.FC = () => {
           {/* <StyledNavImage>
             <img src={peggyplayer} alt='Peggy!'/>
           </StyledNavImage> */}
+          <ul className="nav-token-prices">
+            <li className="nav-price-text"><img src={steakImg} height={27} width={27} alt="Steak logo" /><span>${steakPrice?.toNumber()}</span></li>
+            <li className="nav-price-text"><img src={fusdImg} height={27} width={27} alt="fUSD logo" /><span>${fusdPrice?.toNumber()}</span></li>
+          </ul>
         </nav>
       </IconContext.Provider>
     </>

--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import styled from 'styled-components'
 import * as FaIcons from 'react-icons/fa'
 import * as AiIcons from 'react-icons/ai'
@@ -8,33 +8,49 @@ import AccountButton from './components/AccountButton'
 // import peggyplayer from '../../assets/img/Peggy_Player.png'
 import './components/Navbar.css'
 import { IconContext } from 'react-icons'
+import useWindowWidth from '../../hooks/useWindowWidth'
 
 const NavBar: React.FC = () => {
+  const windowWidth = useWindowWidth()
   const [sidebar, setSidebar] = useState(false)
 
-  const showSidebar = () => setSidebar(!sidebar)
+  const toggleSidebar = () => setSidebar(!sidebar)
+
+  const shouldSidebarBeOpen = () => windowWidth > 1200
+
+  const handleLinkClick = () => {
+    if (!shouldSidebarBeOpen()) {
+      setSidebar(false)
+    }
+  }
+
+  useEffect(() => {
+    if (shouldSidebarBeOpen()) {
+      setSidebar(true)
+    }
+  }, [])
 
   return (
     <>
       <IconContext.Provider value={{ color: '#fff' }}>
         <div className="navbar">
           <Link to="#" className="menu-bars">
-            <FaIcons.FaBars onClick={showSidebar} />
+            <FaIcons.FaBars onClick={toggleSidebar} />
           </Link>
           <StyledAccountButtonWrapper>
             <AccountButton />
           </StyledAccountButtonWrapper>
         </div>
         <nav className={sidebar ? 'nav-menu active' : 'nav-menu'}>
-          <ul className="nav-menu-items" onClick={showSidebar}>
-            <li className="navbar-toggle">
+          <ul className="nav-menu-items">
+            <li className="navbar-toggle" onClick={toggleSidebar}>
               <Link to="#" className="menu-bars">
                 <AiIcons.AiOutlineClose />
               </Link>
             </li>
             {SidebarData.map((item, index) => {
               return (
-                <li key={index} className={item.cName}>
+                <li key={index} className={item.cName} onClick={handleLinkClick}>
                   <Link to={item.path}>
                     {item.icon}
                     <span>{item.title}</span>

--- a/src/components/NavBar/components/Navbar.css
+++ b/src/components/NavBar/components/Navbar.css
@@ -19,7 +19,8 @@
   width: 250px;
   height: 100vh;
   display: flex;
-  justify-content: flex-start;
+  flex-direction: column;
+  justify-content: space-between;
   position: fixed;
   top: 0;
   left: -100%;
@@ -75,6 +76,23 @@ span {
   margin-left: 16px;
 }
 
+.nav-price-text {
+  display: flex;
+  justify-content: start;
+  align-items: center;
+  padding: 8px 0px 8px 16px;
+  list-style: none;
+  height: 60 px;
+  text-decoration: none;
+  color: #f5f5f5;
+  font-size: 18px;
+}
+
+.nav-token-prices {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+}
 
 /* .navbar {
   background: linear-gradient(90deg, rgb(28, 27, 27) 0%, rgb(26, 23, 23) 100%);

--- a/src/hooks/useWindowWidth.ts
+++ b/src/hooks/useWindowWidth.ts
@@ -1,0 +1,21 @@
+import { useState, useEffect } from 'react';
+
+function getWindowWidth() {
+  const { innerWidth: width } = window;
+  return width
+}
+
+export default function useWindowWidth() {
+  const [windowWidth, setWindowWidth] = useState(getWindowWidth());
+
+  useEffect(() => {
+    function handleResize() {
+        setWindowWidth(getWindowWidth());
+    }
+
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  return windowWidth;
+}


### PR DESCRIPTION
1. On first render we check if the window is large enough to fit the sidebar and content in it
- if it is, sidebar is open
- if it isn't, sidebar is closed (including when in mobile)
2. I noticed that it was bit annoying when the sidebar closed everytime I clicked a link. So when clicking on link, we close the sidebar only when window is smaller than set threshold (1200px).
3. Added price of Steak and Fusd to the sidebar. Check attached image.

![image](https://user-images.githubusercontent.com/80589610/127477053-7e66ea83-3fc3-4f2f-beed-4c9d496c2078.png)
